### PR TITLE
ImageWidget render() bypasses FileInput.render()

### DIFF
--- a/form_utils/widgets.py
+++ b/form_utils/widgets.py
@@ -42,7 +42,7 @@ class ImageWidget(forms.FileInput):
         super(ImageWidget, self).__init__(attrs)
 
     def render(self, name, value, attrs=None):
-        input_html = super(forms.FileInput, self).render(name, value, attrs)
+        input_html = super(ImageWidget, self).render(name, value, attrs)
         if hasattr(value, 'width') and hasattr(value, 'height'):
             image_html = thumbnail(value.name, self.width, self.height)
             output = self.template % {'input': input_html,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -473,7 +473,7 @@ class ImageWidgetTests(TestCase):
         """
         widget = ImageWidget()
         html = widget.render('fieldname', FieldFile(None, FileField(), 'something.txt'))
-        self.assertHTMLEqual(html, '<input type="file" name="fieldname" value="something.txt" />')
+        self.assertHTMLEqual(html, '<input type="file" name="fieldname" />')
 
     def test_custom_template(self):
         """


### PR DESCRIPTION
ImageWidget has the following line:

``` python
        input_html = super(forms.FileInput, self).render(name, value, attrs)
```

I don't understand why it's bypassing the FileInput render() method, which would otherwise set value=None so it doesn't appear in the rendered input field.  This seems like a bug, and in fact it breaks testing with WebTest for me, but I don't know if there was a reason you did it this way.
