### PR TITLE
Django form utils has been renamed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGES
 tip (unreleased)
 ----------------
 
+- Fixed compatibility with Django 1.9. Fixed GH-12.
+
 1.0.2 (2014-09-08)
 ------------------
 

--- a/form_utils/forms.py
+++ b/form_utils/forms.py
@@ -9,7 +9,10 @@ from __future__ import unicode_literals
 from copy import deepcopy
 
 from django import forms
-from django.forms.util import flatatt, ErrorDict
+try:
+    from django.forms.utils import flatatt, ErrorDict
+except ImportError: # Django < 1.9 compatibility
+    from django.forms.util import flatatt, ErrorDict
 from django.utils import six
 from django.utils.safestring import mark_safe
 


### PR DESCRIPTION
Adds compatibility import, fixes #12. 

This commit retains backwards compatibility with earlier versions of Django, so should be better suited than this pull request: 
https://bitbucket.org/carljm/django-form-utils/pull-request/5/one-character-update-to-stop/diff