### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,4 +56,4 @@ When submitting a pull request, please note whether you've run the tests with
 tox (and against which versions). Before a pull request can be merged, all
 tests must pass on all configured tox environments.
 
-.. _tox: http://tox.readthedocs.org/en/latest/
+.. _tox: https://tox.readthedocs.io/en/latest/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.